### PR TITLE
import Promise type from dojo-core

### DIFF
--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -1,7 +1,7 @@
 import compose, { ComposeFactory } from 'dojo-compose/compose';
 import createStateful, { Stateful, StatefulOptions, State } from 'dojo-compose/mixins/createStateful';
 import { EventObject } from 'dojo-core/interfaces';
-import { Thenable } from 'dojo-core/Promise';
+import Promise, { Thenable } from 'dojo-core/Promise';
 import Task, { isTask } from 'dojo-core/async/Task';
 import WeakMap from 'dojo-core/WeakMap';
 


### PR DESCRIPTION
Without it a global Promise typing needs to be included in consuming projects.

Ran into this when updating https://github.com/dojo/app/pull/3:

```
typings/globals/dojo-actions/index.d.ts(57,10): error TS2304: Cannot find name 'Promise'.
typings/globals/dojo-actions/index.d.ts(75,10): error TS2304: Cannot find name 'Promise'.
```

Presumably it'll be fine if we just import `Promise` here.
