### PR TITLE
Migration to TS2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .sublimets
 .tscache
+.tsconfig*.json
 *.js
 !/index.js
 *.js.map

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '6.1'
+- '6'
 env:
   global:
   - SAUCE_USERNAME: dojo2-ts-ci
@@ -12,7 +12,7 @@ cache:
   directories:
   - node_modules
 install:
-- "npm install grunt-cli $(node -e \"var deps = require('./package.json').peerDependencies; for(var name in deps) process.stdout.write(name + '@' + deps[name] + ' ');\")"
+- npm install grunt-cli
 - npm install
 script:
 - grunt

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"peerDependencies": {
 		"dojo-core": ">=2.0.0-alpha.8",
 		"dojo-compose": ">=2.0.0-beta.4",
-		"dojo-has": ">=2.0.0-alpha.1",
+		"dojo-has": "next",
 		"dojo-shim": ">=2.0.0-alpha.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"url": "https://github.com/dojo/actions.git"
 	},
 	"scripts": {
-		"prepublish": "grunt dist",
+		"prepublish": "grunt peerDepInstall dist",
 		"test": "grunt test"
 	},
 	"typings": "./dist/umd/dojo-actions.d.ts",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
 		"istanbul": "0.4.3",
 		"remap-istanbul": ">=0.6.4",
 		"tslint": "^3.10.2",
-		"typescript": "~1.8.10"
+		"typescript": "beta"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
 	},
 	"typings": "./dist/umd/dojo-actions.d.ts",
 	"peerDependencies": {
-		"dojo-core": ">=2.0.0-alpha.8",
-		"dojo-compose": ">=2.0.0-beta.4",
+		"dojo-core": "next",
+		"dojo-compose": "next",
 		"dojo-has": "next",
-		"dojo-shim": ">=2.0.0-alpha.1"
+		"dojo-shim": "next"
 	},
 	"devDependencies": {
 		"@reactivex/rxjs": "5.0.0-beta.6",

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -113,32 +113,28 @@ const configureFunctions = new WeakMap<AnyAction, (configuration: Object) => Pro
  * A factory which creates instances of Action
  */
 const createAction: ActionFactory = compose<ActionMixin<any, DoOptions<any, TargettedEventObject<any>>>, ActionOptions<any, ActionState>>({
-		do(options?: DoOptions<any, TargettedEventObject<any>>): Task<any> {
-			const action: AnyAction = this;
-			const doFn = doFunctions.get(action);
-			if (doFn && action.state.enabled) {
-				const result = doFn.call(action, options);
+		do(this: AnyAction, options?: DoOptions<any, TargettedEventObject<any>>): Task<any> {
+			const doFn = doFunctions.get(this);
+			if (doFn && this.state.enabled) {
+				const result = doFn.call(this, options);
 				return isTask(result) ? result : Task.resolve(result);
 			}
 			return Task.resolve();
 		},
-		enable(): void {
-			const action: AnyAction = this;
-			if (!action.state.enabled) {
-				action.setState({ enabled: true });
+		enable(this: AnyAction): void {
+			if (!this.state.enabled) {
+				this.setState({ enabled: true });
 			}
 		},
-		disable(): void {
-			const action: AnyAction = this;
-			if (action.state.enabled) {
-				action.setState({ enabled: false });
+		disable(this: AnyAction): void {
+			if (this.state.enabled) {
+				this.setState({ enabled: false });
 			}
 		},
-		configure(configuration: Object): Promise<void> | void {
-			const action: AnyAction = this;
-			const configureFn = configureFunctions.get(action);
+		configure(this: AnyAction, configuration: Object): Promise<void> | void {
+			const configureFn = configureFunctions.get(this);
 			if (configureFn) {
-				return configureFn.call(action, configuration);
+				return configureFn.call(this, configuration);
 			}
 		}
 	})

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -32,7 +32,7 @@ export const maxConcurrency = 2;
 export const tunnel = 'BrowserStackTunnel';
 
 // Support running unit tests from a web server that isn't the intern proxy
-export const initialBaseUrl: string = (function () {
+export const initialBaseUrl: string | null = (function () {
 	if (typeof location !== 'undefined' && location.pathname.indexOf('__intern/') > -1) {
 		return '/';
 	}

--- a/tests/unit/createAction.ts
+++ b/tests/unit/createAction.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import createAction, { isAction, ActionState, DoOptions, TargettedEventObject } from 'src/createAction';
+import createAction, { isAction, AnyAction, ActionState, DoOptions, TargettedEventObject } from 'src/createAction';
 import Promise from 'dojo-shim/Promise';
 import Task, { isTask } from 'dojo-core/async/Task';
 
@@ -83,7 +83,7 @@ registerSuite({
 				assert.strictEqual(result, 'foo');
 			});
 		},
-		'returns task'() {
+		'returns task'(this: any) {
 			const dfd = this.async();
 			let task: Task<string> = <any> undefined;
 			let count = 0;
@@ -135,7 +135,7 @@ registerSuite({
 		},
 		'scope'() {
 			const action = createAction({
-				do() {
+				do(this: AnyAction) {
 					return this;
 				}
 			});

--- a/tests/unit/createAction.ts
+++ b/tests/unit/createAction.ts
@@ -85,7 +85,7 @@ registerSuite({
 		},
 		'returns task'() {
 			const dfd = this.async();
-			let task: Task<string>;
+			let task: Task<string> = <any> undefined;
 			let count = 0;
 			let executorCount = 0;
 			let finallyCount = 0;
@@ -124,7 +124,7 @@ registerSuite({
 		},
 		'with options'() {
 			const action = createAction<string, DoOptions<string, TargettedEventObject<string>>, ActionState>({
-				do(options) {
+				do(options: any) {
 					return options.event.target;
 				}
 			});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
 		"removeComments": false,
 		"sourceMap": true,
 		"target": "es5",
-		"moduleResolution": "classic"
+		"moduleResolution": "classic",
+		"strictNullChecks": true
 	},
 	"include": [
 		"./src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
 		"sourceMap": true,
 		"target": "es5",
 		"moduleResolution": "classic",
-		"strictNullChecks": true
+		"strictNullChecks": true,
+		"noImplicitThis": true
 	},
 	"include": [
 		"./src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,32 +1,33 @@
 {
-	"version": "1.8.0",
+	"version": "2.0.0",
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
 		"noImplicitAny": true,
 		"outDir": "_build/",
+		"baseUrl": "node_modules",
+		"paths": {
+			"dojo-has/*": [
+				"dojo-has/dist/umd/*"
+			],
+			"dojo-shim/*": [
+				"dojo-shim/dist/umd/*"
+			],
+			"dojo-core/*": [
+				"dojo-core/dist/umd/*"
+			],
+			"dojo-compose/*": [
+				"dojo-compose/dist/umd/*"
+			]
+		},
 		"removeComments": false,
 		"sourceMap": true,
 		"target": "es5",
 		"moduleResolution": "classic"
 	},
-	"filesGlob": [
+	"include": [
 		"./src/**/*.ts",
 		"./tests/**/*.ts",
-		"./typings/index.d.ts"
-	],
-	"files": [
-		"./src/createAction.ts",
-		"./src/main.ts",
-		"./tests/functional/all.ts",
-		"./tests/intern-local.ts",
-		"./tests/intern-saucelabs.ts",
-		"./tests/intern.ts",
-		"./tests/support/Reporter.ts",
-		"./tests/support/util.ts",
-		"./tests/unit/all.ts",
-		"./tests/unit/createAction.ts",
-		"./tests/unit/main.ts",
 		"./typings/index.d.ts"
 	]
 }

--- a/typings.json
+++ b/typings.json
@@ -4,10 +4,6 @@
 		"@reactivex/RxJS": "npm:@reactivex/rxjs"
 	},
 	"globalDependencies": {
-		"dojo-compose": "npm:dojo-compose",
-		"dojo-core": "npm:dojo-core",
-		"dojo-has": "npm:dojo-has",
-		"dojo-shim": "npm:dojo-shim",
 		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Dependant on has, shim, core & compose TS2.0 updates
- [x] Upgrade to TS2.0 (beta)
- [x] Convert to use `paths` and `baseUrl` for UMD type discovery
- [x] Add `strictNullChecks`
- [x] Add `noImplicitThis`

Fixes #4 
