### PR TITLE
update typescript to ~2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dojo-interfaces": ">=2.0.0-alpha.4",
     "dojo-loader": ">=2.0.0-beta.7",
     "grunt": "^1.0.1",
+    "grunt-tslint": "^3.0.0",
     "grunt-dojo2": ">=2.0.0-beta.19",
     "intern": "~3.4.1",
     "istanbul": "~0.4.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "dojo-shim": ">=2.0.0-beta.3"
   },
   "devDependencies": {
-    "@reactivex/rxjs": "5.0.0-beta.6",
     "@types/chai": "~3.4.0",
     "@types/es6-shim": "~0.31.0",
     "@types/glob": "~5.0.0",
@@ -33,9 +32,9 @@
     "dojo-loader": ">=2.0.0-beta.7",
     "grunt": "^1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.19",
-    "intern": "~3.3.2",
+    "intern": "~3.4.1",
     "istanbul": "~0.4.5",
     "tslint": "^3.15.1",
-    "typescript": "~2.0.3"
+    "typescript": "~2.1.4"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,14 +1,9 @@
 {
 	"name": "dojo-actions",
 	"globalDependencies": {
-		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#103096ce945dd51a18cc47a9b7cf9191fdac0349"
+		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
 	},
 	"globalDevDependencies": {
-		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
-		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
+		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1"
 	}
 }


### PR DESCRIPTION
**Type:** feature

**Description:** 

Update `typescript` dependency to `~2.1.4`. Also changes to support Intern `~3.4.1`

**Reference Issue:** #https://github.com/dojo/meta/issues/124